### PR TITLE
Patch: Update image version for openproblems/base_* images

### DIFF
--- a/src/control_methods/true_labels/config.vsh.yaml
+++ b/src/control_methods/true_labels/config.vsh.yaml
@@ -43,7 +43,7 @@ resources:
 engines:
   # Specifications for the Docker image for this component.
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     # Add custom dependencies here (optional). For more information, see
     # https://viash.io/reference/config/engines/docker/#setup .
     # setup:

--- a/src/data_processors/process_dataset/config.vsh.yaml
+++ b/src/data_processors/process_dataset/config.vsh.yaml
@@ -25,7 +25,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 
 runners:
   - type: executable

--- a/src/methods/logistic_regression/config.vsh.yaml
+++ b/src/methods/logistic_regression/config.vsh.yaml
@@ -63,7 +63,7 @@ resources:
 engines:
   # Specifications for the Docker image for this component.
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     # Add custom dependencies here (optional). For more information, see
     # https://viash.io/reference/config/engines/docker/#setup .
     setup:

--- a/src/metrics/accuracy/config.vsh.yaml
+++ b/src/metrics/accuracy/config.vsh.yaml
@@ -54,7 +54,7 @@ resources:
 engines:
   # Specifications for the Docker image for this component.
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     # Add custom dependencies here (optional). For more information, see
     # https://viash.io/reference/config/engines/docker/#setup .
     setup:


### PR DESCRIPTION
This PR updates the image version from :1.0.0 to :1 for `openproblems/base_*` images.