### PR TITLE
Write the commit and timestamp into task_info.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,5 +26,8 @@
 
 * Updated `README.md` (PR #5).
 
+* `run_benchmark`: write the commit the workflow ran from and the launch time into
+  `task_info.yaml`, instead of publishing `_viash.yaml` verbatim (PR #18).
+
 ## BUGFIXES
 

--- a/src/workflows/run_benchmark/main.nf
+++ b/src/workflows/run_benchmark/main.nf
@@ -164,14 +164,23 @@ workflow run_wf {
       metric_configs_file.write(metric_configs_yaml_blob)
 
       // store the task info in a file
-      def viash_file = meta.resources_dir.resolve("_viash.yaml")
+      def task_info = readYaml(meta.resources_dir.resolve("_viash.yaml"))
+      // commitId is null when nextflow runs from a local checkout instead of a revision
+      if (workflow.commitId) {
+        task_info.commit = workflow.commitId
+      }
+      // the launch time -- workflow.complete is only known once the run is over
+      task_info.timestamp = workflow.start.toInstant()
+        .truncatedTo(java.time.temporal.ChronoUnit.SECONDS).toString()
+      def task_info_file = tempFile("task_info.yaml")
+      task_info_file.write(toYamlBlob(task_info))
 
       // create output state
       def new_state = [
         output_dataset_info: dataset_uns_file,
         output_method_configs: method_configs_file,
         output_metric_configs: metric_configs_file,
-        output_task_info: viash_file,
+        output_task_info: task_info_file,
         _meta: states[0]._meta
       ]
 


### PR DESCRIPTION
## Describe your changes

`task_info.yaml` was published as a verbatim copy of `_viash.yaml`:

```groovy
def viash_file = meta.resources_dir.resolve("_viash.yaml")
```

so it could only ever contain things known at build time, and nothing in a published
result pinned it to the run that produced it. Two fields were missing:

* **`commit`** -- `task_info.json` has a field for it, but the closest `_viash.yaml`
  gets is `version: build_main`, which is the revision rather than a commit, and
  `build/main` moves.
* **`timestamp`** -- required by `common/schemas/results_v4/task_info.json`. Nothing
  was writing it, so `render_results_report` has been guessing: it parses a date out
  of a `run_<date>` results path, and falls back to the modification time of
  `task_info.yaml` if the path does not have one.

`run_benchmark` now reads `_viash.yaml`, adds both, and writes that out instead:

```yaml
name: task_template
version: build_main
commit: 2dc5486b62cc1dc65b0abf371be898f8c246027e
timestamp: '2026-07-30T13:36:58Z'
...
```

`workflow.commitId` is null when Nextflow runs from a local checkout rather than a
revision it resolved itself, so that field is only added when we actually know it,
rather than writing a placeholder. The timestamp is the launch time rather than the
completion time, because `workflow.complete` is only known once the run is over, and
this closure runs before that -- it also lines up with the `run_<date>` directory name
that the reporting side was inferring from anyway.

Checked against Nextflow 26.04 that `workflow.start` is an `OffsetDateTime`, that
`.toInstant().truncatedTo(SECONDS).toString()` gives `2026-07-30T13:36:58Z`, that
snakeyaml quotes it so it stays a string rather than a YAML timestamp, and that
`yaml::read_yaml()` reads it back as a character -- so it passes ajv's `date-time`
check. Comments in `_viash.yaml` do not survive the parse/serialise round trip, which
seemed a fair trade for a file that only ever gets parsed.

Same change as openproblems-bio/task_spatial_simulators#33 and
openproblems-bio/task_spatial_simulators#34, sent here as promised in the first of
those. The reporting side reads the `commit` field as of
openproblems-bio/openproblems#943; it already preferred the `timestamp` from
`task_info.yaml` over its `--timestamp` argument.

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [x] Minor changes
  - [ ] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] CI Tests succeed and look good!
